### PR TITLE
Update toolkit_SMILES_docs_comparison.asciidoc

### DIFF
--- a/toolkit_doc_compare/toolkit_SMILES_docs_comparison.asciidoc
+++ b/toolkit_doc_compare/toolkit_SMILES_docs_comparison.asciidoc
@@ -47,7 +47,7 @@ document.
 |Toolkit | SMILES Higher Order Stereochemistry Support
 
 |*CACTVS v3.4.8.3* | *AL, SP, TB, OH*
-|*CDK v2.0* | *AL*
+|*CDK v2.0* | *AL, SP, TB, OH*
 |ChemAxon 2019 | -
 |ChemDoodle v9.1 | ?
 |*Indigo 1.3.0 beta* | *AL*
@@ -64,7 +64,7 @@ document.
 |Toolkit | Internal Model(s) |  Daylight (like) | Tripos | MDL | MMFF | Customizable
 
 |CACTVS v3.4.8.3 | ✓ | ✓ | - | - | - | -
-|CDK v2.0 | ✓ | ✓ | - |  - | - | ✓
+|CDK v2.0 | ✓ | ✓ | - |  ✓ | - | ✓
 |ChemAxon 2019 | ✓  | ✓  | -  | -  | - | -
 |ChemDoodle v9.1 | ✓ | - | - | - | - | -
 |Indigo 1.3.0 beta | ✓ | - | - | - | - | -
@@ -81,7 +81,7 @@ document.
 |Toolkit | Daylight SMARTS** | CXSMILES | R Groups `[Z]` or `[R]` | Aromatic `[te]`
 
 |CACTVS v3.4.8.3 | ✓ | - | - | -
-|CDK v2.0 | ✓ | ✓ | - | -
+|CDK v2.0 | ✓ | ✓ | ✓ | ✓
 |ChemAxon 2019 |  ✓ | ✓ | ✓ | -
 |ChemDoodle v9.1 | ✓ | - | - | -
 |Indigo 1.3.0 beta | ✓ | ✓ | - | -


### PR DESCRIPTION
Not sure where this information was got from: 
 - CDK does support the SP/TB/OH stereo. How else do you think I can [depict them](https://www.simolecule.com/cdkdepict/depict.html)? Also I don't actually think OpenBabel does support them, at least not when I was testing before. There is allowing them to be parsed in the syntax vs correct round tripping/depiction etc.
- CDK "PiBonds" model is MDL-like, this is documented. Also the "CDK internal" model is essentially Tripos in all but name but I'll leave that.
- ``[te]`` is allowed to be read but not written. CDK actually supports the same as OEChem IIRC inc. ``[Pb]``, and even ``[Al]`` - [CHEBI:35905](https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:35905).  I tried to get this added to OpenSMILES - [discussion](https://sourceforge.net/p/blueobelisk/mailman/message/31310750/). Depict link: https://www.simolecule.com/cdkdepict/depict/bow/svg?smi=%5Bte%5D1cccc1%20%5Bte%5D1cccc1&abbr=on&hdisp=bridgehead&showtitle=true&zoom=1.6&annotate=none
- ``[R1]`` also supported on read but not write (can write as CXSMILES)  Depict link: https://www.simolecule.com/cdkdepict/depict/bow/svg?smi=%5BR1%5DCCC%20%5BR1%5DCCC&abbr=on&hdisp=bridgehead&showtitle=true&zoom=1.6&annotate=none