### PR TITLE
Clear up ring numbering rule

### DIFF
--- a/IUPAC_SMILES+.asciidoc
+++ b/IUPAC_SMILES+.asciidoc
@@ -581,7 +581,7 @@ has been encountered twice, that number is available again for subsequent ring c
 Two-digit ring numbers are permitted, but must be preceded by the percent
 `'%'` symbol, such as `C%25CCCCC%25` for cyclohexane. 
 
-Three digit ring numbers must use parentheses, `%(nnn)`, and start with `100`. This is to avoid
+Three digit ring numbers must use parentheses, `%(nnn)`, and start at `100`. This is to avoid
 the ambiguity of, for example `C%123` being interpreted as one ring closure (`%123`) or two (`%12` and `3`).
 When parentheses are used, the ring closure is interpreted with one rnum specification, so cyclohexane
 can be represented as `C%(123)CCCCC%(123)`


### PR DESCRIPTION
The phrasing `starts with 100` could also be interpreted as `prefixed with 100` upon the initial read. Alternatively, the entire second part of the sentence could be removed since the same numbering rule is reiterated in the next paragraph.